### PR TITLE
Some cleanup and fixes for Buster builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # linuxcnc-live-build
 
-    sudo lb config -m http://archive.debian.org/debian --parent-mirror-chroot-security  http://archive.debian.org/debian-security --parent-mirror-binary http://archive.debian.org/debian
+    git clone https://github.com/LinuxCNC/linuxcnc-live-build
+    cd linuxcnc-live-build
+    git checkout buster
+    lb config
     sudo lb build
     
     Puts the .iso file in images{desktop}
-    
-    

--- a/auto/config
+++ b/auto/config
@@ -3,16 +3,18 @@
 set -e
 
 lb config noauto \
-	--linux-packages linux-image-4.19.0-9-rt\
+	--linux-packages linux-image-rt \
 	--distribution buster \
 	--binary-images iso-hybrid \
 	--debian-installer live \
 	--archive-areas "main contrib non-free" \
 	--iso-application "LinuxCNC-2.8.2" \
-	--iso-preparer "bodgesoc@gmail.com" \
+	--iso-preparer "emc-developers@lists.sourceforge.net" \
 	--iso-volume "LinuxCNC_2.8.2" \
 	--image-name "LinuxCNC_2.8.2" \
 	--iso-publisher "www.linuxcnc.org" \
 	--apt-recommends true \
+	--parent-mirror-bootstrap http://deb.debian.org/debian \
+	--parent-mirror-binary http://deb.debian.org/debian \
+	--parent-mirror-chroot-security http://deb.debian.org/debian-security \
 	"${@}"
- 

--- a/config/package-lists/linuxcnc.list
+++ b/config/package-lists/linuxcnc.list
@@ -1,9 +1,7 @@
-linuxcnc-uspace 
+linuxcnc-uspace
 linuxcnc-uspace-dev
 linuxcnc-doc-es
 linuxcnc-doc-fr
 linuxcnc-doc-en
 hostmot2-firmware-all
 mesaflash
-
-

--- a/patches/binary_syslinux.patch
+++ b/patches/binary_syslinux.patch
@@ -1,0 +1,20 @@
+Pass more values on to the SVG generation.
+
+Submitted upstream as <URL: https://bugs.debian.org/1015782 >.
+
+Patch by Andy Pugh.
+
+--- binary_syslinux?inline=false	2022-07-21 08:24:47.290238867 +0200
++++ patches/binary_syslinux	2022-07-21 08:02:59.462562152 +0200
+@@ -257,6 +257,11 @@
+ 			-e "s|@LIVE_BOOT_VERSION@|${_LIVE_BOOT_VERSION}|g" \
+ 			-e "s|@LIVE_CONFIG_VERSION@|${_LIVE_CONFIG_VERSION}|g" \
+ 			-e "s|@LIVE_TOOLS_VERSION@|${_LIVE_TOOLS_VERSION}|g" \
++			-e "s|@LB_ISO_APPLICATION@|${LB_ISO_APPLICATION}|g" \
++			-e "s|@LB_ISO_PREPARER@|${LB_ISO_PREPARER}|g" \
++			-e "s|@LB_ISO_PUBLISHER@|${LB_ISO_PUBLISHER}|g" \
++			-e "s|@LB_ISO_VOLUME@|${LB_ISO_VOLUME}|g" \
++			-e "s|@LB_LINUX_PACKAGES@|${LB_LINUX_PACKAGES}|g" \
+ 		"${_FILE}"
+ 	fi
+ done


### PR DESCRIPTION
Rewrote README.md build instructions to build from the wanted branch.
Changed APT source used from archive.debian.org to deb.debian.org to
use the new CDN like archive source.  Added the patch used for
binary_syslinux with annontations about its upstream status.  Changed
preparer email from personal to community list.  Changed kernel package
to the generic one instead of specific versioned one.  Removed some
useless whitespace.