### PR TITLE
Removed obsolete firmware-intelwimax from list of packages to install

### DIFF
--- a/config/package-lists/firmware.list
+++ b/config/package-lists/firmware.list
@@ -10,7 +10,6 @@ firmware-bnx2
 firmware-bnx2x
 firmware-brcm80211
 firmware-cavium
-firmware-intelwimax
 firmware-ipw2x00
 firmware-iwlwifi
 firmware-libertas


### PR DESCRIPTION
The package has been removed from testing and unstable.