### PR TITLE
Drop light-locker from set of installed packages

### DIFF
--- a/config/package-lists/desktop.list
+++ b/config/package-lists/desktop.list
@@ -1,4 +1,5 @@
 lightdm
+light-locker-
 xfce4
 xfce4-terminal
 task-xfce-desktop


### PR DESCRIPTION
This causes xscreensaver to be installed instead, and live-config know how to disable the screen saver password locking with xscreensaver. The effect is that users are no longer locked out of the desktop when the screen saver kick in.

Fixes: #16