### PR TITLE
Fix bookworm discrepancy of kernel modules with live installer

### DIFF
--- a/auto/config
+++ b/auto/config
@@ -6,7 +6,7 @@ lb config noauto \
 	--linux-packages linux-image-rt \
 	--distribution bookworm \
 	--binary-images iso-hybrid \
-	--debian-installer live \
+	--debian-installer netboot \
 	--archive-areas "main contrib non-free" \
 	--iso-application "LinuxCNC-2.9pre2" \
 	--iso-preparer "emc-developers@lists.sourceforge.net" \


### PR DESCRIPTION
The "live" installer is special wrt the kernel that is used, which is not from bookworm. That led to the kernel modules from the bookworm distribution not matching the executing kernel and to an error message plus non-configurable networks.