### PR TITLE
Added apt update so we get linuxcnc from the Linuxcnc.org repository

### DIFF
--- a/config/hooks/normal/510-linuxcnc.hook.chroot
+++ b/config/hooks/normal/510-linuxcnc.hook.chroot
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+apt update


### PR DESCRIPTION
**Untested (but logs show it works)**
**PLEASE Test before release**
I think this hook is run after all of the sources are set up so by doing an apt update here, we should get linuxcnc from the linuxcnc.org repository not Debian 12 which has a very Old version of LInuxcnc