### PR TITLE
update for 2.9.4

### DIFF
--- a/auto/config
+++ b/auto/config
@@ -9,10 +9,10 @@ lb config noauto \
 	--binary-images iso-hybrid \
 	--debian-installer live \
 	--archive-areas "main contrib non-free non-free-firmware" \
-	--iso-application "LinuxCNC-2.9.3" \
+	--iso-application "LinuxCNC-2.9.4" \
 	--iso-preparer "emc-developers@lists.sourceforge.net" \
-	--iso-volume "LinuxCNC_2.9.3" \
-	--image-name "LinuxCNC_2.9.3" \
+	--iso-volume "LinuxCNC_2.9.4" \
+	--image-name "LinuxCNC_2.9.4" \
 	--iso-publisher "www.linuxcnc.org" \
 	--apt-recommends true \
 	--security true \

--- a/config/build
+++ b/config/build
@@ -5,6 +5,6 @@ Distribution: bookworm
 Mirror-Bootstrap: http://deb.debian.org/debian/
 
 [FIXME]
-Configuration-Version: 1:20230919
-Name: LinuxCNC_2.9pre
+Configuration-Version: 1:20250127
+Name: LinuxCNC_2.9.4
 Type: iso-hybrid


### PR DESCRIPTION
Test this. It should work. The only changes to this from 2.9.3 is to change to the version in the file build
I will upload the ISO image to Google drive once built
When I thought about this, there is no change to the 2.9.3 version except the latest version will pull down Linuxcnc 2.9.4 from the repository. So all the keys etc should work as th apt upgrade workes fine

You must build this on a bookworm PC because the Debian Live build uses the version of Debian installed. Also uupgrade to the latest version with
```
sudo apt update
sudo apt upgrade
```
before starting the build