### PR TITLE
add os-prober to packages to be installed

### DIFF
--- a/config/package-lists/desktop.list
+++ b/config/package-lists/desktop.list
@@ -50,6 +50,7 @@ rt-tests
 linux-headers-rt-amd64
 dkms
 grub-customizer
+os-prober
 wget
 curl
 gdebi


### PR DESCRIPTION
For reasons beyond my understanding, the installer fails to install grub-pc if it can't install os-prober. The os-prober debian package is not included in the image. Result is that installs without network connection don't work.

remedy: add os-prober package to our package-list.

edit: fixed typo